### PR TITLE
file-associations:Return from the busy cursor only after the Ui stuff ended

### DIFF
--- a/lxqt-config-file-associations/applicationchooser.cpp
+++ b/lxqt-config-file-associations/applicationchooser.cpp
@@ -88,6 +88,7 @@ void ApplicationChooser::updateAllIcons() {
         }
     }
     QCoreApplication::processEvents();
+    QApplication::restoreOverrideCursor();
 }
 
 void ApplicationChooser::fillApplicationListWidget()
@@ -130,7 +131,6 @@ void ApplicationChooser::fillApplicationListWidget()
     connect(widget.applicationTreeWidget, SIGNAL(currentItemChanged(QTreeWidgetItem*, QTreeWidgetItem*)), this, SLOT(selectionChanged()));
     widget.applicationTreeWidget->setFocus();
 
-    QApplication::restoreOverrideCursor();
     if (!applicationsThatHandleThisMimetype.isEmpty()) {
         widget.buttonBox->button(QDialogButtonBox::Ok)->setEnabled(true);
     }


### PR DESCRIPTION
Processing the icons in a delayed batch mode is a great, great idea.
The cursor should be kept in the busy state until the Ui updating really
ends.