### PR TITLE
Initial support for locale config, based on formats KCMS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,7 @@ add_subdirectory(lxqt-config-input)
 add_subdirectory(lxqt-config-file-associations)
 add_subdirectory(lxqt-config-appearance)
 add_subdirectory(lxqt-config-monitor)
+add_subdirectory(lxqt-config-locale)
 
 # building tarball with CPack -------------------------------------------------
 include(InstallRequiredSystemLibraries)

--- a/lxqt-config-locale/CMakeLists.txt
+++ b/lxqt-config-locale/CMakeLists.txt
@@ -1,0 +1,82 @@
+project(lxqt-config-locale)
+
+include_directories(
+    ${QTXDG_PRIVATE_INCLUDE_DIRS}
+    ${Qt5Gui_PRIVATE_INCLUDE_DIRS}
+    ${LXQT_INCLUDE_DIRS}
+    ${QTXDG_INCLUDE_DIRS}
+)
+
+set(H_FILES
+    localeconfig.h
+)
+
+set(MOC_FILES
+    localeconfig.h
+)
+
+set(CPP_FILES
+    main.cpp
+    localeconfig.cpp
+)
+
+set(UI_FILES
+    localeconfig.ui
+)
+
+set(QRC_FILES "")
+
+set(LIBRARIES
+    ${QTXDG_LIBRARIES}
+    ${LXQT_LIBRARIES}
+)
+
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
+CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
+if(COMPILER_SUPPORTS_CXX11)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+elseif(COMPILER_SUPPORTS_CXX0X)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
+else()
+    message(FATAL "The compiler ${CMAKE_CXX_COMPILER} has no C++11 support. C++11 support is required")
+endif()
+
+# Translations **********************************
+lxqt_translate_ts(QM_FILES
+        UPDATE_TRANSLATIONS ${UPDATE_TRANSLATIONS}
+    SOURCES
+        ${H_FILES}
+        ${CPP_FILES}
+        ${UI_FILES}
+    INSTALL_DIR
+        "${LXQT_TRANSLATIONS_DIR}/${PROJECT_NAME}"
+)
+
+lxqt_app_translation_loader(QM_LOADER ${PROJECT_NAME})
+lxqt_translate_desktop(DESKTOP_FILES SOURCES ${PROJECT_NAME}.desktop.in)
+
+#************************************************
+
+qt5_wrap_ui(UI_HEADERS ${UI_FILES})
+qt5_add_resources(QRC_SOURCES ${QRC_FILES})
+
+add_executable(${PROJECT_NAME}
+    ${CPP_FILES}
+    ${UI_FILES}
+    ${RESOURCES}
+    ${QRC_SOURCES}
+    ${QM_FILES}
+    ${QM_LOADER}
+    ${MOC_SOURCES}
+    ${DESKTOP_FILES}
+)
+
+target_link_libraries(${PROJECT_NAME}
+    Qt5::Widgets
+    Qt5::Xml
+    ${LIBRARIES}
+)
+
+install(TARGETS ${PROJECT_NAME} RUNTIME DESTINATION bin)
+install(FILES ${DESKTOP_FILES} DESTINATION ${CMAKE_INSTALL_PREFIX}/share/applications)

--- a/lxqt-config-locale/localeconfig.cpp
+++ b/lxqt-config-locale/localeconfig.cpp
@@ -1,0 +1,450 @@
+/* BEGIN_COMMON_COPYRIGHT_HEADER
+ * (c)GPL2+
+ *
+ *
+ * Copyright: 2014 LXQt team
+ *            2014 Sebastian Kügler <sebas@kde.org>
+ * Authors:
+ *   Julien Lavergne <gilir@ubuntu.com>
+ *   Sebastian Kügler <sebas@kde.org>
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *
+ * END_COMMON_COPYRIGHT_HEADER
+ *
+ * Based on plasma-desktop/kcms/formats module
+ */
+
+#include "localeconfig.h"
+#include "ui_localeconfig.h"
+
+#include <QApplication>
+#include <QComboBox>
+#include <QFile>
+#include <QDebug>
+#include <QLocale>
+#include <QStandardPaths>
+#include <QTextStream>
+#include <QTextCodec>
+#include <QDateTime>
+#include <QMessageBox>
+
+const static QString lcLang = QStringLiteral("LANG");
+
+const static QString lcNumeric = QStringLiteral("LC_NUMERIC");
+const static QString lcTime = QStringLiteral("LC_TIME");
+const static QString lcMonetary = QStringLiteral("LC_MONETARY");
+const static QString lcMeasurement = QStringLiteral("LC_MEASUREMENT");
+const static QString lcCollate = QStringLiteral("LC_COLLATE");
+const static QString lcCtype = QStringLiteral("LC_CTYPE");
+
+const static QString lcLanguage = QStringLiteral("LANGUAGE");
+
+LocaleConfig::LocaleConfig(LxQt::Settings* settings, LxQt::Settings* session_settings, QWidget* parent) :
+    QWidget(parent),
+    mSettings(settings),
+    sSettings(session_settings),
+    hasChanged(new bool),
+    m_ui(new Ui::LocaleConfig)
+    
+{
+    m_ui->setupUi(this);
+    m_combos << m_ui->comboGlobal
+             << m_ui->comboNumbers
+             << m_ui->comboTime
+             << m_ui->comboCurrency
+             << m_ui->comboMeasurement
+             << m_ui->comboCollate;
+
+    hasChanged = false;
+
+    initControls();
+}
+
+
+LocaleConfig::~LocaleConfig()
+{
+    delete m_ui;
+}
+
+bool countryLessThan(const QLocale & c1, const QLocale & c2)
+{
+    return QString::localeAwareCompare(c1.nativeCountryName(), c2.nativeCountryName()) < 0;
+}
+
+void LocaleConfig::load()
+{
+    QList<QLocale> allLocales = QLocale::matchingLocales(QLocale::AnyLanguage, QLocale::AnyScript, QLocale::AnyCountry);
+    qSort(allLocales.begin(), allLocales.end(), countryLessThan);
+    foreach(QComboBox * combo, m_combos)
+    {
+        initCombo(combo, allLocales);
+    }
+
+    readConfig();
+
+    foreach(QComboBox * combo, m_combos)
+    {
+        connectCombo(combo);
+    }
+
+    connect(m_ui->checkDetailed, &QAbstractButton::toggled, [ = ]()
+    {
+        updateExample();
+        updateEnabled();
+        hasChanged = true;
+    });
+
+    updateEnabled();
+    updateExample();
+    hasChanged = false;
+}
+
+void LocaleConfig::initCombo(QComboBox *combo, const QList<QLocale> & allLocales)
+{
+    combo->clear();
+    const QString clabel = tr("No change");
+    combo->addItem(clabel, QString());
+    foreach(const QLocale & l, allLocales)
+    {
+        addLocaleToCombo(combo, l);
+    }
+}
+
+void LocaleConfig::connectCombo(QComboBox *combo)
+{
+    connect(combo, &QComboBox::currentTextChanged, [ = ]()
+    {
+        hasChanged = true;
+        updateExample();
+    });
+}
+
+void LocaleConfig::addLocaleToCombo(QComboBox *combo, const QLocale &locale)
+{
+    const QString clabel = !locale.nativeCountryName().isEmpty() ? locale.nativeCountryName() : locale.countryToString(locale.country());
+    // This needs to use name() rather than bcp47name() or later on the export will generate a non-sense locale (e.g. "it" instead of
+    // "it_IT")
+    // TODO: Properly handle scripts (@foo)
+    QString cvalue = locale.name();
+    if (!cvalue.contains('.'))
+    { // explicitely add the encoding, otherwise Qt doesn't accept dead keys and garbles the output as well
+        cvalue.append(QLatin1Char('.') + QTextCodec::codecForLocale()->name());
+    }
+
+    QString flagcode;
+    const QStringList split = locale.name().split('_');
+    if (split.count() > 1)
+    {
+        flagcode = split[1].toLower();
+    }
+    /* TODO Find a better place for flags ... */
+    QString flag(QStandardPaths::locate(QStandardPaths::GenericDataLocation, QStringLiteral("kf5/locale/countries/%1/flag.png").arg(flagcode)));
+    QIcon flagIcon;
+    if (!flag.isEmpty())
+    {
+        flagIcon = QIcon(flag);
+    }
+
+    QString itemResult;
+    itemResult = QString("%1 - %2 (%3)")
+                        .arg(clabel)
+                        .arg(locale.nativeLanguageName())
+                        .arg(locale.name());
+
+    combo->addItem(flagIcon, itemResult, cvalue);
+}
+
+void setCombo(QComboBox *combo, const QString &key)
+{
+    const int ix = combo->findData(key);
+    if (ix > -1)
+    {
+        combo->setCurrentIndex(ix);
+    }
+}
+
+void LocaleConfig::readConfig()
+{
+    mSettings->beginGroup("Formats");
+
+    bool useDetailed = mSettings->value("useDetailed", false).toBool();
+    m_ui->checkDetailed->setChecked(useDetailed);
+
+    setCombo(m_ui->comboGlobal, mSettings->value(lcLang, qgetenv(lcLang.toLatin1())).toString());
+
+    setCombo(m_ui->comboNumbers, mSettings->value(lcNumeric, qgetenv(lcNumeric.toLatin1())).toString());
+    setCombo(m_ui->comboTime, mSettings->value(lcTime, qgetenv(lcTime.toLatin1())).toString());
+    setCombo(m_ui->comboCollate, mSettings->value(lcCollate, qgetenv(lcCollate.toLatin1())).toString());
+    setCombo(m_ui->comboCurrency, mSettings->value(lcMonetary, qgetenv(lcMonetary.toLatin1())).toString());
+    setCombo(m_ui->comboMeasurement, mSettings->value(lcMeasurement, qgetenv(lcMeasurement.toLatin1())).toString());
+
+    updateEnabled();
+
+    mSettings->endGroup();
+}
+
+void LocaleConfig::writeConfig()
+{
+    mSettings->beginGroup("Formats");
+
+    // global ends up empty here when OK button is clicked from kcmshell5,
+    // apparently the data in the combo is gone by the time save() is called.
+    // This might be a problem in KCModule, but does not directly affect us
+    // since within systemsettings, it works fine.
+    // See https://bugs.kde.org/show_bug.cgi?id=334624
+    if (m_ui->comboGlobal->count() == 0)
+    {
+        qWarning() << "Couldn't read data from UI, writing configuration failed.";
+        return;
+    }
+    const QString global = m_ui->comboGlobal->currentData().toString();
+
+    if (!m_ui->checkDetailed->isChecked())
+    {
+        // Global setting, clean up config
+        mSettings->remove("useDetailed");
+        if (global.isEmpty())
+        {
+            mSettings->remove(lcLang);
+        }
+        else
+        {
+            mSettings->setValue(lcLang, global);
+        }
+        mSettings->remove(lcNumeric);
+        mSettings->remove(lcTime);
+        mSettings->remove(lcMonetary);
+        mSettings->remove(lcMeasurement);
+        mSettings->remove(lcCollate);
+        mSettings->remove(lcCtype);
+    }
+    else
+    {
+        // Save detailed settings
+        mSettings->setValue("useDetailed", true);
+
+        if (global.isEmpty())
+        {
+            mSettings->remove(lcLang);
+        }
+        else
+        {
+            mSettings->setValue(lcLang, global);
+        }
+
+        const QString numeric = m_ui->comboNumbers->currentData().toString();
+        if (numeric.isEmpty())
+        {
+            mSettings->remove(lcNumeric);
+        }
+        else
+        {
+            mSettings->setValue(lcNumeric, numeric);
+        }
+
+        const QString time = m_ui->comboTime->currentData().toString();
+        if (time.isEmpty())
+        {
+            mSettings->remove(lcTime);
+        } 
+        else
+        {
+            mSettings->setValue(lcTime, time);
+        }
+
+        const QString monetary = m_ui->comboCurrency->currentData().toString();
+        if (monetary.isEmpty())
+        {
+            mSettings->remove(lcMonetary);
+        }
+        else
+        {
+            mSettings->setValue(lcMonetary, monetary);
+        }
+
+        const QString measurement = m_ui->comboMeasurement->currentData().toString();
+        if (measurement.isEmpty())
+        {
+            mSettings->remove(lcMeasurement);
+        }
+        else
+        {
+            mSettings->setValue(lcMeasurement, measurement);
+        }
+
+        const QString collate = m_ui->comboCollate->currentData().toString();
+        if (collate.isEmpty())
+        {
+            mSettings->remove(lcCollate);
+        } 
+        else
+        {
+            mSettings->setValue(lcCollate, collate);
+        }
+    }
+    mSettings->endGroup();
+}
+
+void LocaleConfig::saveSettings()
+{
+    if (hasChanged)
+    {
+        QMessageBox msgBox;
+        msgBox.setWindowTitle(tr("Format Settings Changed"));
+        msgBox.setText(tr("Save the settings ? (they will take effect the next time you log in)"));
+        msgBox.setStandardButtons(QMessageBox::Save | QMessageBox::Cancel);
+        msgBox.setDefaultButton(QMessageBox::Cancel);
+        
+        int ret = msgBox.exec();
+        if( ret == QMessageBox::Save )
+        {
+            writeConfig();
+            writeExports();
+        }
+    }
+
+}
+
+void LocaleConfig::writeExports()
+{
+    sSettings->beginGroup("Environment");
+    mSettings->beginGroup("Formats");
+    if (!mSettings->value(lcLang).toString().isNull())
+    {
+        sSettings->setValue(lcLang, mSettings->value(lcLang).toString());
+
+        if (mSettings->value("useDetailed").toBool())
+        {
+            if (!mSettings->value(lcNumeric).toString().isNull())
+            {
+                sSettings->setValue(lcNumeric, mSettings->value(lcNumeric).toString());
+            }
+            if (!mSettings->value(lcTime).toString().isNull())
+            {
+                sSettings->setValue(lcTime, mSettings->value(lcTime).toString());
+            }
+            if (!mSettings->value(lcCollate).toString().isNull())
+            {
+                sSettings->setValue(lcCollate, mSettings->value(lcCollate).toString());
+            }
+            if (!mSettings->value(lcMonetary).toString().isNull())
+            {
+                sSettings->setValue(lcMonetary, mSettings->value(lcMonetary).toString());
+            }
+            if (!mSettings->value(lcMeasurement).toString().isNull())
+            {
+                sSettings->setValue(lcMeasurement, mSettings->value(lcMeasurement).toString());
+            }
+        }
+        else
+        {
+            sSettings->setValue(lcNumeric, mSettings->value(lcLang).toString());
+            sSettings->setValue(lcTime, mSettings->value(lcLang).toString());
+            sSettings->setValue(lcCollate, mSettings->value(lcLang).toString());
+            sSettings->setValue(lcMonetary, mSettings->value(lcLang).toString());
+            sSettings->setValue(lcMeasurement, mSettings->value(lcLang).toString());
+        }
+    }
+    mSettings->endGroup();
+    sSettings->endGroup();
+    sSettings->sync();
+}
+
+void LocaleConfig::defaults()
+{
+    m_ui->checkDetailed->setChecked(false);
+
+    // restore user defaults from env vars
+    setCombo(m_ui->comboGlobal, qgetenv(lcLang.toLatin1()));
+    setCombo(m_ui->comboNumbers, qgetenv(lcNumeric.toLatin1()));
+    setCombo(m_ui->comboTime, qgetenv(lcTime.toLatin1()));
+    setCombo(m_ui->comboCollate, qgetenv(lcCollate.toLatin1()));
+    setCombo(m_ui->comboCurrency, qgetenv(lcMonetary.toLatin1()));
+    setCombo(m_ui->comboMeasurement, qgetenv(lcMeasurement.toLatin1()));
+
+    updateEnabled();
+}
+
+void LocaleConfig::updateEnabled()
+{
+    const bool enabled = m_ui->checkDetailed->isChecked();
+
+    m_ui->labelNumbers->setEnabled(enabled);
+    m_ui->labelTime->setEnabled(enabled);
+    m_ui->labelCurrency->setEnabled(enabled);
+    m_ui->labelMeasurement->setEnabled(enabled);
+    m_ui->labelCollate->setEnabled(enabled);
+    m_ui->comboNumbers->setEnabled(enabled);
+    m_ui->comboTime->setEnabled(enabled);
+    m_ui->comboCurrency->setEnabled(enabled);
+    m_ui->comboMeasurement->setEnabled(enabled);
+    m_ui->comboCollate->setEnabled(enabled);
+}
+
+void LocaleConfig::updateExample()
+{
+    const bool useDetailed = m_ui->checkDetailed->isChecked();
+
+    QLocale nloc;
+    QLocale tloc;
+    QLocale cloc;
+    QLocale mloc;
+
+    if (useDetailed)
+    {
+        nloc = QLocale(m_ui->comboNumbers->currentData().toString());
+        tloc = QLocale(m_ui->comboTime->currentData().toString());
+        cloc = QLocale(m_ui->comboCurrency->currentData().toString());
+        mloc = QLocale(m_ui->comboMeasurement->currentData().toString());
+    } 
+    else
+    {
+        nloc = QLocale(m_ui->comboGlobal->currentData().toString());
+        tloc = QLocale(m_ui->comboGlobal->currentData().toString());
+        cloc = QLocale(m_ui->comboGlobal->currentData().toString());
+        mloc = QLocale(m_ui->comboGlobal->currentData().toString());
+    }
+
+    const QString numberExample = nloc.toString(1000.01);
+    const QString timeExample = tloc.toString(QDateTime::currentDateTime());
+    const QString currencyExample = cloc.toCurrencyString(24);
+
+    QString measurementSetting;
+    if (mloc.measurementSystem() == QLocale::ImperialUKSystem)
+    {
+        measurementSetting = tr("Imperial UK");
+    }
+    else if (mloc.measurementSystem() == QLocale::ImperialUSSystem)
+    {
+        measurementSetting = tr("Imperial US");
+    }
+    else
+    {
+        measurementSetting = tr("Metric");
+    }
+
+    m_ui->exampleNumbers->setText(numberExample);
+    m_ui->exampleTime->setText(timeExample);
+    m_ui->exampleCurrency->setText(currencyExample);
+    m_ui->exampleMeasurement->setText(measurementSetting);
+}
+
+void LocaleConfig::initControls()
+{
+    defaults();
+    load();
+    hasChanged = false;
+}

--- a/lxqt-config-locale/localeconfig.h
+++ b/lxqt-config-locale/localeconfig.h
@@ -1,0 +1,79 @@
+/* BEGIN_COMMON_COPYRIGHT_HEADER
+ * (c)GPL2+
+ *
+ *
+ * Copyright: 2014 LXQt team
+ *            2014 Sebastian Kügler <sebas@kde.org>
+ * Authors:
+ *   Julien Lavergne <gilir@ubuntu.com>
+ *   Sebastian Kügler <sebas@kde.org>
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
+
+#ifndef LOCALECONFIG_H
+#define LOCALECONFIG_H
+
+#include <QWidget>
+#include <LXQt/Settings>
+
+class QTreeWidgetItem;
+class QSettings;
+
+
+namespace Ui {
+    class LocaleConfig;
+}
+
+class QComboBox;
+class QMessageWidget;
+
+class LocaleConfig : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit LocaleConfig(LxQt::Settings *settings, LxQt::Settings *session_settings, QWidget *parent = 0);
+    ~LocaleConfig();
+
+    void load();
+    void save();
+    void defaults();
+
+public slots:
+    void initControls();
+    void saveSettings();
+
+private:
+    void addLocaleToCombo(QComboBox *combo, const QLocale &locale);
+    void initCombo(QComboBox *combo, const QList<QLocale> &allLocales);
+    void connectCombo(QComboBox *combo);
+    QList<QComboBox *> m_combos;
+
+    void readConfig();
+    void writeConfig();
+    void writeExports();
+
+    void updateExample();
+    void updateEnabled();
+
+    Ui::LocaleConfig *m_ui;
+    bool hasChanged;
+    LxQt::Settings *mSettings;
+    LxQt::Settings *sSettings;
+};
+
+#endif // LOCALECONFIG_H

--- a/lxqt-config-locale/localeconfig.ui
+++ b/lxqt-config-locale/localeconfig.ui
@@ -1,0 +1,385 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <author>Sebastian Kuegler</author>
+ <class>LocaleConfig</class>
+ <widget class="QWidget" name="LocaleConfig">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>600</width>
+    <height>450</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <spacer name="verticalSpacer_2">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>16</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="1">
+      <layout class="QFormLayout" name="formLayout">
+       <property name="fieldGrowthPolicy">
+        <enum>QFormLayout::ExpandingFieldsGrow</enum>
+       </property>
+       <property name="horizontalSpacing">
+        <number>6</number>
+       </property>
+       <property name="verticalSpacing">
+        <number>6</number>
+       </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_10">
+         <property name="text">
+          <string>Re&amp;gion:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="buddy">
+          <cstring>comboGlobal</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="comboGlobal">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>300</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QCheckBox" name="checkDetailed">
+         <property name="text">
+          <string>De&amp;tailed Settings</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="labelNumbers">
+         <property name="text">
+          <string>&amp;Numbers:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="buddy">
+          <cstring>comboNumbers</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QComboBox" name="comboNumbers">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>300</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="labelTime">
+         <property name="text">
+          <string>&amp;Time:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="buddy">
+          <cstring>comboTime</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QComboBox" name="comboTime">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>300</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="labelCurrency">
+         <property name="text">
+          <string>Currenc&amp;y:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="buddy">
+          <cstring>comboCurrency</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QComboBox" name="comboCurrency">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>300</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="labelMeasurement">
+         <property name="text">
+          <string>Measurement &amp;Units:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="buddy">
+          <cstring>comboMeasurement</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QComboBox" name="comboMeasurement">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>300</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="labelCollate">
+         <property name="text">
+          <string>Co&amp;llation and Sorting:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+         <property name="buddy">
+          <cstring>comboCollate</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="1">
+        <widget class="QComboBox" name="comboCollate">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>300</width>
+           <height>0</height>
+          </size>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="label_6">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0">
+        <widget class="QLabel" name="labelMeasurement_2">
+         <property name="text">
+          <string>&lt;b&gt;Examples&lt;/b&gt;</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="0">
+        <widget class="QLabel" name="lexNumbers">
+         <property name="text">
+          <string>Numbers:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="1">
+        <widget class="QLabel" name="exampleNumbers">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="0">
+        <widget class="QLabel" name="lexTime">
+         <property name="text">
+          <string>Time:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="1">
+        <widget class="QLabel" name="exampleTime">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="0">
+        <widget class="QLabel" name="lexCurrency">
+         <property name="text">
+          <string>Currency:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+        </widget>
+       </item>
+       <item row="11" column="1">
+        <widget class="QLabel" name="exampleCurrency">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="0">
+        <widget class="QLabel" name="lexMeasurement_2">
+         <property name="text">
+          <string>Measurement Units:</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="1">
+        <widget class="QLabel" name="exampleMeasurement">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="0" column="2">
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>16</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="0">
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>16</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>32</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/lxqt-config-locale/lxqt-config-locale.desktop.in
+++ b/lxqt-config-locale/lxqt-config-locale.desktop.in
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Locale
+GenericName=Locale settings
+Comment=Locale settings for LXQt
+Exec=lxqt-config-locale
+Icon=preferences-desktop-locale
+Categories=Settings;DesktopSettings;Qt;LXQt;
+OnlyShowIn=LXDE;LXQt;
+
+#TRANSLATIONS_DIR=translations

--- a/lxqt-config-locale/main.cpp
+++ b/lxqt-config-locale/main.cpp
@@ -1,0 +1,53 @@
+/* BEGIN_COMMON_COPYRIGHT_HEADER
+ * (c)GPL2+
+ *
+ *
+ * Copyright: 2014 LXQt team
+ *
+ * Authors:
+ *   Julien Lavergne <gilir@ubuntu.com>
+ *
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *
+ * END_COMMON_COPYRIGHT_HEADER */
+
+#include <LXQt/SingleApplication>
+
+#include <XdgIcon>
+#include <LXQt/Settings>
+#include <LXQt/ConfigDialog>
+#include "localeconfig.h"
+
+int main (int argc, char **argv)
+{
+    LxQt::SingleApplication app(argc, argv);
+    LxQt::Settings settings("lxqt-config-locale");
+    LxQt::Settings session_settings("lxqt-session");
+    LxQt::ConfigDialog* dialog = new LxQt::ConfigDialog(QObject::tr("LXQt Locale Configuration"), &settings);
+
+    app.setActivationWindow(dialog);
+
+    LocaleConfig* localePage = new LocaleConfig(&settings, &session_settings, dialog);
+    dialog->addPage(localePage, QObject::tr("Locale Settings"), QStringList() << "preferences-desktop-locale" << "preferences-desktop");
+    QObject::connect(dialog, SIGNAL(reset()), localePage, SLOT(initControls()));
+    QObject::connect(dialog, SIGNAL(save()), localePage, SLOT(saveSettings()));
+
+    dialog->setAttribute(Qt::WA_DeleteOnClose);
+    dialog->setWindowIcon(QIcon::fromTheme("preferences-desktop-locale"));
+    dialog->show();
+
+    return app.exec();
+}
+

--- a/lxqt-config-locale/man/lxqt-config-locale.1
+++ b/lxqt-config-locale/man/lxqt-config-locale.1
@@ -1,0 +1,25 @@
+.TH lxqt-config-locale "17" "March 2015" "LXQt\ 0.9.0" "LXQt\ GUI settings"
+.SH NAME
+lxqt-config-locale \- GUI locale settings application of \fBLXQt\fR: the faster and lighter QT Desktop Environment
+.SH SYNOPSIS
+.B lxqt-config-locale
+.br
+.SH DESCRIPTION
+With this application you can setting and configuring default language, digits format, and other regional customization.
+.P
+.SH "REPORTING BUGS"
+Report bugs to https://github.com/lxde/lxde-qt/issues
+.SH "SEE ALSO"
+\fBLXQt\fR it has been tailored for users who value simplicity, speed, and
+an intuitive interface, also intended for less powerful machines. See also:
+.\" any module must refers to session app, for more info on start it
+.P
+\fBlxqt-session.1\fR  LXQt module for manage LXQt complete environment.
+.P
+\fBlxqt-config.1\fR  LXQt application for general config and settings.
+.P
+\fBqtconfig-qt4.1\fR  Qt4 application for gui and appereance settings over all qt4 based software.
+.P
+.SH AUTHOR
+This manual page was created by \fBPICCORO Lenz McKAY\fR \fI<mckaygerhard@gmail.com>\fR
+for \fBLXQt\fR project and VENENUX GNU/Linux but can be used by others.


### PR DESCRIPTION
This is an initial support for a locale config, which make possible to switch languages and formats. It's heavily based on the KDE one, adapted to lxqt-config, and save the environment variables directly in lxqt-session (issue lxde/lxqt#546).

I have currently 2 issues which I was unable to solve : 
- I have a double free crash when closing the app, and I think it's because I use 2 LXQt settings, but I don't know why the crash still exist.
- I don't know how to generate the template for the translation (if I missed the doc, please point me to it).

Let me know if there is other things to look at. Thanks in advance for the review :-)