### PR TITLE
Include X-LXQt category in lxqt-config menu

### DIFF
--- a/src/lxqt-config.menu
+++ b/src/lxqt-config.menu
@@ -19,6 +19,7 @@
                 <Category>DesktopSettings</Category>
                 <Or>
                     <Category>LXQt</Category>
+                    <Category>X-LXQt</Category>
                     <!-- Include some optional components here -->
                     <Filename>obconf-qt.desktop</Filename>
                     <Filename>compton-conf.desktop</Filename>


### PR DESCRIPTION
Some distributions patch our .desktop files to use' X-LXQt' instead of
'LXQt' to get Freedesktop conform desktop files.
See: http://sourceforge.net/p/lxde/mailman/message/34154860/

LXQt config only displays in the lxqt settings category if you have
category set to "LXQt" I ORed it to accept "X-LXQt" too.

The long term fix should be to get registered with Freedesktop.org