### PR TITLE
the license of qt-xcurtheme is WTFPL 2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,8 +6,8 @@ Copyright:
     Copyright (c) 2010-2012 Razor team
     Copyright (c) 2012-2014 LXQt team
 
-License: GPL-2 and LGPL-2.1+
+License: LGPL-2.1+ and WTFPL 2
 The full text of the licenses can be found in the 'COPYING' file.
 
 The lxqt-config-cursor component is based on the "qt-xcurtheme" project
-and is licensed under GPL 2.
+and is licensed under WTFPL 2.


### PR DESCRIPTION
WTFPL 2 is a valid free non-permissive FOSS License acknowledged by the FSF