### PR TITLE
Make the lxqt-config-locale chosen settings work

### DIFF
--- a/lxqt-config-locale/main.cpp
+++ b/lxqt-config-locale/main.cpp
@@ -33,8 +33,8 @@
 int main (int argc, char **argv)
 {
     LXQt::SingleApplication app(argc, argv);
-    LXQt::Settings settings("LXQt-config-locale");
-    LXQt::Settings session_settings("LXQt-session");
+    LXQt::Settings settings("lxqt-config-locale");
+    LXQt::Settings session_settings("session");
     LXQt::ConfigDialog* dialog = new LXQt::ConfigDialog(QObject::tr("LXQt Locale Configuration"), &settings);
 
     app.setActivationWindow(dialog);


### PR DESCRIPTION
The settings were being written to the wrong config files.
Discussed at https://github.com/lxde/lxqt-config/pull/55.