### PR TITLE
Allow absolute and relative libdir paths

### DIFF
--- a/lxqt-config-appearance/CMakeLists.txt
+++ b/lxqt-config-appearance/CMakeLists.txt
@@ -75,10 +75,17 @@ target_link_libraries(${PROJECT_NAME}
     lxqt-config-cursor
 )
 
-set_target_properties("${PROJECT_NAME}"
-    PROPERTIES
-    INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/${LXQT_CONFIG_PROJECT}"
-)
+if(IS_ABSOLUTE ${CMAKE_INSTALL_LIBDIR})
+  set_target_properties(lxqt-config-input
+      PROPERTIES
+      INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR}/${LXQT_CONFIG_PROJECT}"
+  )
+else(IS_ABSOLUTE ${CMAKE_INSTALL_LIBDIR})
+  set_target_properties(lxqt-config-input
+      PROPERTIES
+      INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/${LXQT_CONFIG_PROJECT}"
+  )
+endif(IS_ABSOLUTE ${CMAKE_INSTALL_LIBDIR})
 
 install(TARGETS
     ${PROJECT_NAME}

--- a/lxqt-config-input/CMakeLists.txt
+++ b/lxqt-config-input/CMakeLists.txt
@@ -66,10 +66,19 @@ target_link_libraries(lxqt-config-input
     lxqt-config-cursor
 )
 
-set_target_properties(lxqt-config-input
-    PROPERTIES
-    INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/${LXQT_CONFIG_PROJECT}"
-)
+
+if(IS_ABSOLUTE ${CMAKE_INSTALL_LIBDIR})
+  set_target_properties(lxqt-config-input
+      PROPERTIES
+      INSTALL_RPATH "${CMAKE_INSTALL_LIBDIR}/${LXQT_CONFIG_PROJECT}"
+  )
+else(IS_ABSOLUTE ${CMAKE_INSTALL_LIBDIR})
+  set_target_properties(lxqt-config-input
+      PROPERTIES
+      INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/${LXQT_CONFIG_PROJECT}"
+  )
+endif(IS_ABSOLUTE ${CMAKE_INSTALL_LIBDIR})
+
 
 install(TARGETS
     lxqt-config-input


### PR DESCRIPTION
In openSUSE we provide _libdir to CMAKE_INSTALL_LIBDIR and not _lib. This patch
makes it work wither with an absolute path or relative. So it should
work in any case.