### PR TITLE
Initial support for different paths of xkb base.lst in different OSes.

### DIFF
--- a/lxqt-config-input/keyboardlayoutconfig.cpp
+++ b/lxqt-config-input/keyboardlayoutconfig.cpp
@@ -94,8 +94,8 @@ enum ListSection{
 
 void KeyboardLayoutConfig::loadLists() {
   // load known lists from xkb data files
-  // FIXME: maybe we should use different files for different OSes?
-  QFile file(QLatin1String("/usr/share/X11/xkb/rules/base.lst"));
+  // XKBD_BASELIST_PATH is os dependent see keyboardlayoutconfig.h
+  QFile file(QLatin1String(XKBD_BASELIST_PATH));
   if(file.open(QIODevice::ReadOnly)) {
     ListSection section = NoSection;
     while(!file.atEnd()) {

--- a/lxqt-config-input/keyboardlayoutconfig.h
+++ b/lxqt-config-input/keyboardlayoutconfig.h
@@ -21,6 +21,17 @@
 #ifndef KEYBOARDLAYOUTCONFIG_H
 #define KEYBOARDLAYOUTCONFIG_H
 
+#include <QtCore/QtGlobal>
+#ifdef Q_OS_LINUX
+#define XKBD_BASELIST_PATH "/usr/share/X11/xkb/rules/base.lst"
+#elif defined(Q_OS_FREEBSD)
+#define XKBD_BASELIST_PATH "/usr/local/share/X11/xkb/rules/base.lst"
+#elif defined(Q_OS_OPENBSD)
+#define XKBD_BASELIST_PATH "/usr/X11R6/share/X11/xkb/rules/base.lst"
+#else
+#define XKBD_BASELIST_PATH "/usr/local/share/X11/xkb/rules/base.lst"
+#endif
+
 #include <QWidget>
 #include "keyboardlayoutinfo.h"
 #include <QMap>


### PR DESCRIPTION
Using Qt5 Q_OS_LINUX, Q_OS_FREEBSD, and Q_OS_OPENBSD  I did set the filepath of "base.lst" accordingly for GNU/Linux FreeBSD and OpenBSD defaulting to the path of FreeBSD. 

It has been tested on Linux as well as FreeBSD. A minimal test has been run on OpenBSD for future use on OpenBSD. If the file does not exist nothing crashes the keyboard layout list is simply empty.