### PR TITLE
font config: make it possible to write custom fontconfig files

### DIFF
--- a/lxqt-config-appearance/fontconfigfile.cpp
+++ b/lxqt-config-appearance/fontconfigfile.cpp
@@ -179,6 +179,7 @@ void FontConfigFile::save()
         "<!DOCTYPE fontconfig SYSTEM \"fonts.dtd\">\n"
         "<!-- created by lxqt-config-appearance (DO NOT EDIT!) -->\n"
         "<fontconfig>\n"
+        "  <include ignore_missing=\"yes\">conf.d</include>\n"
         "  <match target=\"font\">\n"
         "    <edit name=\"antialias\" mode=\"assign\">\n"
         "      <bool>" << (mAntialias ? "true" : "false") << "</bool>\n"


### PR DESCRIPTION
Right now, lxqt-config-appearance overwrites the `fonts.conf` file. That is rather annoying if you have other options in that file that lxqt-config does not know or understand (like fine-tuning the font aliasing).

This commit adds an "include" line to the generated `fonts.conf` so that one can drop custom files in `~/.config/fontconfig/conf.d`. According to `man fonts.conf`, that is a standard location, but it still has to be explicitly included by the `fonts.conf`.