### PR TITLE
Use const references with the foreach iterator

### DIFF
--- a/lxqt-config-appearance/iconthemeconfig.cpp
+++ b/lxqt-config-appearance/iconthemeconfig.cpp
@@ -58,7 +58,7 @@ IconThemeConfig::IconThemeConfig(LXQt::Settings* settings, QWidget* parent):
 void IconThemeConfig::initIconsThemes()
 {
     QStringList processed;
-    QStringList baseDirs = QIcon::themeSearchPaths();
+    const QStringList baseDirs = QIcon::themeSearchPaths();
     static const QStringList iconNames = QStringList()
                     << QStringLiteral("document-open")
                     << QStringLiteral("document-new")
@@ -69,14 +69,14 @@ void IconThemeConfig::initIconsThemes()
     iconThemeList->setColumnCount(iconNamesN + 2);
 
     QList<QTreeWidgetItem *> items;
-    foreach (QString baseDirName, baseDirs)
+    foreach (const QString &baseDirName, baseDirs)
     {
         QDir baseDir(baseDirName);
         if (!baseDir.exists())
             continue;
 
-        QFileInfoList dirs = baseDir.entryInfoList(QDir::AllDirs | QDir::NoDotAndDotDot, QDir::Name);
-        foreach (QFileInfo dir, dirs)
+        const QFileInfoList dirs = baseDir.entryInfoList(QDir::AllDirs | QDir::NoDotAndDotDot, QDir::Name);
+        foreach (const QFileInfo &dir, dirs)
         {
             if (!processed.contains(dir.canonicalFilePath()))
             {

--- a/lxqt-config-file-associations/mimetypeitemmodel.cpp
+++ b/lxqt-config-file-associations/mimetypeitemmodel.cpp
@@ -188,7 +188,7 @@ bool MimetypeFilterItemModel::filterHelper(QModelIndex& source_index) const
         return true;
     }
 
-    foreach (const QString pattern, mimeInfo->patterns())
+    foreach (const QString &pattern, mimeInfo->patterns())
     {
         if (pattern.contains(filterRegExp()))
         {


### PR DESCRIPTION
We should use const references whenever possible.