### PR TITLE
lxqt-config-appearance: Use fewer XdgIcon* stuff

### DIFF
--- a/lxqt-config-appearance/iconthemeconfig.cpp
+++ b/lxqt-config-appearance/iconthemeconfig.cpp
@@ -27,15 +27,10 @@
 
 #include "iconthemeconfig.h"
 
-#include <XdgDesktopFile>
-#include <XdgIcon>
 #include <LXQt/Settings>
 #include <QStringList>
 #include <QStringBuilder>
 #include <QIcon>
-#include <QDebug>
-
-#include <private/xdgiconloader/xdgiconloader_p.h>
 
 IconThemeConfig::IconThemeConfig(LXQt::Settings* settings, QWidget* parent):
     QWidget(parent),
@@ -47,9 +42,6 @@ IconThemeConfig::IconThemeConfig(LXQt::Settings* settings, QWidget* parent):
     initControls();
     connect(iconThemeList, SIGNAL(itemClicked(QTreeWidgetItem*,int)),
             this, SLOT(iconThemeSelected(QTreeWidgetItem*,int)));
-
-    connect(LXQt::Settings::globalSettings(), SIGNAL(settingsChanged()),
-            this, SLOT(update()));
 }
 
 
@@ -112,7 +104,6 @@ void IconThemeConfig::initIconsThemes()
             }
         }
     }
-    XdgIconLoader::instance()->updateSystemTheme();
 
     iconThemeList->insertTopLevelItems(0, items);
     for (int i=0; i<iconThemeList->header()->count()-1; ++i)
@@ -124,8 +115,7 @@ void IconThemeConfig::initIconsThemes()
 
 void IconThemeConfig::initControls()
 {
-    QString currentTheme = LXQt::Settings::globalSettings()->value("icon_theme").toString();
-    XdgIcon::setThemeName(currentTheme);
+    QString currentTheme = QIcon::themeName();
     QTreeWidgetItemIterator it(iconThemeList);
     while (*it) {
         if ((*it)->data(0, Qt::UserRole).toString() == currentTheme)
@@ -151,12 +141,6 @@ void IconThemeConfig::iconThemeSelected(QTreeWidgetItem *item, int column)
     QString theme = item->data(0, Qt::UserRole).toString();
     if (!theme.isEmpty())
     {
-        XdgIcon::setThemeName(theme);
-
-        // An hack to ensure that this widget also re loads it's own icons
-        // from the selected icon theme.
-        XdgIconLoader::instance()->setThemeName(QString());
-
         m_settings->setValue("icon_theme",  theme);
         m_settings->sync();
     }

--- a/lxqt-config-appearance/iconthemeinfo.cpp
+++ b/lxqt-config-appearance/iconthemeinfo.cpp
@@ -126,7 +126,6 @@ QVector<QIcon> IconThemeInfo::icons(const QStringList &iconNames) const
 {
     QVector<QIcon> icons;
 
-    const QString currentThemeName = XdgIconLoader::instance()->themeName();
     XdgIconLoader::instance()->setThemeName(mName);
     foreach (const QString &i, iconNames) {
         QThemeIconInfo info = XdgIconLoader::instance()->loadIcon(i);
@@ -161,6 +160,6 @@ QVector<QIcon> IconThemeInfo::icons(const QStringList &iconNames) const
             icons.append(QIcon());
         }
     }
-    XdgIconLoader::instance()->setThemeName(currentThemeName);
+    XdgIconLoader::instance()->setThemeName(QString());
     return icons;
 }

--- a/lxqt-config-appearance/main.cpp
+++ b/lxqt-config-appearance/main.cpp
@@ -26,9 +26,7 @@
  * END_COMMON_COPYRIGHT_HEADER */
 
 #include <LXQt/SingleApplication>
-#include <QDebug>
 
-#include <XdgIcon>
 #include <LXQt/Settings>
 #include <LXQt/ConfigDialog>
 #include "iconthemeconfig.h"


### PR DESCRIPTION
As the XdgIconLoader is now used as backend for all QIcon stuff (if lxqt-qtplugin is used), use the XdgIcon* stuf as least as possible -> let the lxqt-qtplugin & Qt handle it.