### PR TITLE
lxqt-config-appearance: Fix a null pointer dereference

### DIFF
--- a/lxqt-config-appearance/iconthemeinfo.cpp
+++ b/lxqt-config-appearance/iconthemeinfo.cpp
@@ -154,7 +154,10 @@ QVector<QIcon> IconThemeInfo::icons(const QStringList &iconNames) const
                         closestMatch = entry;
                     }
                 }
-                icons.append(QIcon(closestMatch->filename));
+                if (closestMatch)
+                    icons.append(QIcon(closestMatch->filename));
+                else
+                    icons.append(QIcon());
             }
         } else {
             icons.append(QIcon());


### PR DESCRIPTION
If (distance < minimalSize) is never true, we end up dereferencing
closestMatch that was initialized to a null pointer.