### PR TITLE
appearance: Do (not) change wallpaper with theme

### DIFF
--- a/lxqt-config-appearance/lxqtthemeconfig.ui
+++ b/lxqt-config-appearance/lxqtthemeconfig.ui
@@ -51,6 +51,16 @@
      </column>
     </widget>
    </item>
+   <item>
+    <widget class="QCheckBox" name="wallpaperOverride">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Override independently set wallper</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <resources/>


### PR DESCRIPTION
When chaning the LXQt theme, the wallpaper will be changed only if it
wasn't changed by the user independently (the config value
wallpaperChanged is set by pcmanfm-qt). But we can override chaning the
wallpaper (new checkbox added).


This needs lxde/pcmanfm-qt#396

closes lxde/lxqt#156