### PR TITLE
brightness: Add change confirmation dialog

### DIFF
--- a/lxqt-config-brightness/brightnesssettings.h
+++ b/lxqt-config-brightness/brightnesssettings.h
@@ -20,6 +20,7 @@
 #define __BRIGHTNESS_SETTINGS_H__
 
 #include <QDialog>
+#include <QTimer>
 #include "xrandrbrightness.h"
 #include "ui_brightnesssettings.h"
 
@@ -31,11 +32,17 @@ Q_OBJECT
 public:
     BrightnessSettings(QWidget *parent =0);
 
+signals:
+    void monitorReverted(const MonitorInfo & monitor);
+
 public slots:
     void monitorSettingsChanged(MonitorInfo monitor);
+    void requestConfirmation();
 
 private:
     XRandrBrightness *mBrightness;
+    QList<MonitorInfo> mMonitors;
+    QTimer mConfirmRequestTimer;
     Ui::BrightnessSettings *ui;
 
 

--- a/lxqt-config-brightness/brightnesssettings.ui
+++ b/lxqt-config-brightness/brightnesssettings.ui
@@ -30,6 +30,16 @@
     <layout class="QVBoxLayout" name="layout"/>
    </item>
    <item>
+    <widget class="QCheckBox" name="confirmCB">
+     <property name="text">
+      <string>Require confirmation after settings change</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>

--- a/lxqt-config-brightness/outputwidget.cpp
+++ b/lxqt-config-brightness/outputwidget.cpp
@@ -54,3 +54,15 @@ void OutputWidget::brightnessChanged(int value)
     emit changed(mMonitor);
 }
 
+void OutputWidget::setRevertedValues(const MonitorInfo & monitor)
+{
+    if (mMonitor.id() == monitor.id() && mMonitor.name() == monitor.name())
+    {
+        ui->backlightSlider->blockSignals(true);
+        ui->backlightSlider->setValue(monitor.backlight());
+        ui->backlightSlider->blockSignals(false);
+        ui->brightnessSlider->blockSignals(true);
+        ui->brightnessSlider->setValue(monitor.brightness()*100);
+        ui->brightnessSlider->blockSignals(false);
+    }
+}

--- a/lxqt-config-brightness/outputwidget.h
+++ b/lxqt-config-brightness/outputwidget.h
@@ -35,6 +35,7 @@ signals:
 public slots:
     void backlightChanged(int value);
     void brightnessChanged(int value);
+    void setRevertedValues(const MonitorInfo & monitor);
 private:
     MonitorInfo mMonitor;
     Ui::OutputWidget *ui;


### PR DESCRIPTION
After settings change (1 sec restartable timeout) the confirmation is
requested (confirmation checkbox is default checked). The dialog will
timeout/cancel automaticaly (after 5 seconds) if the user doesn't
confirm it.

By this we are avoiding unrecoverable setting (full white/black screen).

closes lxde/lxqt#973