### PR TITLE
all: Remove XdgIcon & XdgIconLoader usage

### DIFF
--- a/lxqt-config-file-associations/mimetypeviewer.cpp
+++ b/lxqt-config-file-associations/mimetypeviewer.cpp
@@ -34,7 +34,6 @@
 #include <QDateTime>
 #include <QFileInfo>
 
-#include <XdgIcon>
 #include <XdgDesktopFile>
 #include <XdgDirs>
 #include <LXQt/Settings>

--- a/lxqt-config-locale/main.cpp
+++ b/lxqt-config-locale/main.cpp
@@ -25,7 +25,6 @@
 
 #include <LXQt/SingleApplication>
 
-#include <XdgIcon>
 #include <LXQt/Settings>
 #include <LXQt/ConfigDialog>
 #include "localeconfig.h"


### PR DESCRIPTION
We don't need to use the XdgIcon any more, as the XdgIconLoader is used
as the default QIconEngine (thanks to our platform theme plugin -
lxqt-qtplugin).

For the very same reason, the (duplicated) icon searching logic was
removed from lxqt-config-appearance/iconthemeinfor.cpp.

closes #101