### PR TITLE
lxqt-config-monitor: remove unnecessary wait before settings load

### DIFF
--- a/lxqt-config-monitor/loadsettings.cpp
+++ b/lxqt-config-monitor/loadsettings.cpp
@@ -26,13 +26,11 @@
 #include <KScreen/SetConfigOperation>
 #include <LXQt/Settings>
 #include <KScreen/EDID>
-#include <QThread>
 #include <QCoreApplication>
 
 
 LoadSettings::LoadSettings(QObject *parent):QObject(parent)
 {
-    QThread::sleep(10); // KScreen is  slow loading screen modes
     KScreen::GetConfigOperation *operation  = new KScreen::GetConfigOperation();
     connect(operation, &KScreen::GetConfigOperation::finished, [this, operation] (KScreen::ConfigOperation *op) {
         KScreen::GetConfigOperation *configOp = qobject_cast<KScreen::GetConfigOperation *>(op);


### PR DESCRIPTION
Recent versions of kscreen (tested with latest 5.8.5 and also with 5.6)
don't have any noticeable slowness so remove this random magic number wait
because it's very anoying when using lxqt-config-monitor -l to restore
previously saved configurations.

Signed-off-by: Ioan-Adrian Ratiu <adi@adirat.com>