### PR TITLE
Show non-primary screens in UI.

### DIFF
--- a/lxqt-config-monitor/monitorwidget.cpp
+++ b/lxqt-config-monitor/monitorwidget.cpp
@@ -154,6 +154,8 @@ MonitorWidget::MonitorWidget(KScreen::OutputPtr output, KScreen::ConfigPtr confi
     // Behavior chooser
     if (output->isPrimary())
         ui.behaviorCombo->setCurrentIndex(PrimaryDisplay);
+    else
+        ui.behaviorCombo->setCurrentIndex(ExtendDisplay);
 
     // Insert orientations
     ui.orientationCombo->addItem(tr("None"), KScreen::Output::None);


### PR DESCRIPTION
Fix a simple bug in UI. Extend display option is shown when screen is not a primary screen:

![captura](https://cloud.githubusercontent.com/assets/1163139/23251322/2bad1b36-f9ad-11e6-9a3e-5063ba913007.png)
