### PR TITLE
Fix build with CMake 3.8

### DIFF
--- a/liblxqt-config-cursor/CMakeLists.txt
+++ b/liblxqt-config-cursor/CMakeLists.txt
@@ -74,6 +74,16 @@ add_library(lxqt-config-cursor
         ${lxqt-config-cursor_QM_LOADER}
 )
 
+if(CMAKE_VERSION VERSION_LESS 3.8.0)
+    set(UI_PATH "${CMAKE_CURRENT_BINARY_DIR}")
+else(CMAKE_VERSION VERSION_LESS 3.8.0)
+    set(UI_PATH "${CMAKE_CURRENT_BINARY_DIR}/lxqt-config-cursor_autogen/include")
+endif(CMAKE_VERSION VERSION_LESS 3.8.0)
+
+set_target_properties(lxqt-config-cursor PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR};${UI_PATH}")
+
+
 target_link_libraries(lxqt-config-cursor
     Qt5::X11Extras
     Qt5::DBus

--- a/lxqt-config-appearance/CMakeLists.txt
+++ b/lxqt-config-appearance/CMakeLists.txt
@@ -2,8 +2,6 @@ project(lxqt-config-appearance)
 
 include_directories(
     ${Qt5Gui_PRIVATE_INCLUDE_DIRS}
-    "${CMAKE_CURRENT_SOURCE_DIR}/../liblxqt-config-cursor"
-    "${CMAKE_CURRENT_BINARY_DIR}/../liblxqt-config-cursor"
 )
 
 set(H_FILES

--- a/lxqt-config-input/CMakeLists.txt
+++ b/lxqt-config-input/CMakeLists.txt
@@ -3,8 +3,6 @@ find_package(X11 REQUIRED)
 
 include_directories(
     ${X11_INCLUDE_DIR}
-    "${CMAKE_CURRENT_SOURCE_DIR}/../liblxqt-config-cursor"
-    "${CMAKE_CURRENT_BINARY_DIR}/../liblxqt-config-cursor"
 )
 
 set(lxqt-config-input_HDRS


### PR DESCRIPTION
In CMake 3.8, the path to generated ui_*.h files is changed.

Fixes https://github.com/lxde/lxqt/issues/1277

The new path is documented, [1] so I hard-coded it. The current approach looks ugly as there are duplicated codes. Unfortunately I'm not familiar with CMake enough to give an elegant fix.

```
The generated generated ui_*.h files are placed in the <CMAKE_CURRENT_BINARY_DIR>/<TARGETNAME>_autogen/include directory which is automatically added to the target’s INCLUDE_DIRECTORIES.
```
[1] https://cmake.org/cmake/help/v3.8/manual/cmake-qt.7.html#autouic