### PR TITLE
lxqt-config-file-associations: Sets the initial focus

### DIFF
--- a/lxqt-config-file-associations/mimetypeviewer.cpp
+++ b/lxqt-config-file-associations/mimetypeviewer.cpp
@@ -113,6 +113,7 @@ MimetypeViewer::MimetypeViewer(QWidget *parent)
     mSettingsCache->loadFromSettings();
     initializeMimetypeTreeView();
     loadAllMimeTypes();
+    widget.searchTermLineEdit->setFocus();
 
     connect(widget.mimetypeTreeWidget, SIGNAL(itemSelectionChanged()),
             this, SLOT(currentMimetypeChanged()));
@@ -146,7 +147,6 @@ void MimetypeViewer::initializeMimetypeTreeView()
 {
     currentMimetypeChanged();
     widget.mimetypeTreeWidget->setColumnCount(2);
-    widget.mimetypeTreeWidget->setFocus();
     widget.searchTermLineEdit->setEnabled(true);
 }
 


### PR DESCRIPTION
Sets the initial focus to the search text box.