### PR TITLE
lxqt-config-locale: corrected/reworded Save Changed Settings dialog

### DIFF
--- a/lxqt-config-locale/localeconfig.cpp
+++ b/lxqt-config-locale/localeconfig.cpp
@@ -306,7 +306,7 @@ void LocaleConfig::saveSettings()
     {
         QMessageBox msgBox;
         msgBox.setWindowTitle(tr("Format Settings Changed"));
-        msgBox.setText(tr("Save the settings ? (they will take effect the next time you log in)"));
+        msgBox.setText(tr("Do you want to save your changes? They will take effect the next time you log in."));
         msgBox.setStandardButtons(QMessageBox::Save | QMessageBox::Cancel);
         msgBox.setDefaultButton(QMessageBox::Cancel);
         


### PR DESCRIPTION
I stumbled over a grammatical error in lxqt-config-locale's changed settings dialog.

I took the liberty of not only removing the irritating misplaced space, but also rewording the dialog slightly.