### PR TITLE
Update monitorsettingsdialog.ui

### DIFF
--- a/lxqt-config-monitor/monitorsettingsdialog.ui
+++ b/lxqt-config-monitor/monitorsettingsdialog.ui
@@ -56,7 +56,7 @@
       </property>
       <property name="minimumSize">
        <size>
-        <width>300</width>
+        <width>350</width>
         <height>0</height>
        </size>
       </property>


### PR DESCRIPTION
Expanding right panel to avoid truncate tabs.
![monitor1](https://user-images.githubusercontent.com/10681413/30515387-e3f127da-9b26-11e7-8385-0845dfaa36e7.png)
after:
 
![schermata-16-21-38-22](https://user-images.githubusercontent.com/10681413/30515415-6416a4da-9b27-11e7-8e73-ad60958ccd00.png)
