### PR TITLE
Use $XDG_CONFIG_HOME/mimeapps.list for mime data instead of …

### DIFF
--- a/lxqt-config-file-associations/mimetypeviewer.cpp
+++ b/lxqt-config-file-associations/mimetypeviewer.cpp
@@ -107,7 +107,7 @@ MimetypeViewer::MimetypeViewer(QWidget *parent)
     connect(widget.chooseApplicationsButton, SIGNAL(clicked()), this, SLOT(chooseApplication()));
     connect(widget.dialogButtonBox, SIGNAL(clicked(QAbstractButton*)), this, SLOT(dialogButtonBoxClicked(QAbstractButton*)));
 
-    QString mimeappsListPath(XdgDirs::dataHome(true) + "/applications/mimeapps.list");
+    QString mimeappsListPath(XdgDirs::configHome(true) + "/mimeapps.list");
     mDefaultsList = new QSettings(mimeappsListPath, XdgDesktopFileCache::desktopFileSettingsFormat(), this);
     mSettingsCache = new LXQt::SettingsCache(mDefaultsList);
     mSettingsCache->loadFromSettings();


### PR DESCRIPTION
…$XDG_DATA_HOME/applications/mimeapps.list

According to latest spec [https://specifications.freedesktop.org/mime-apps-spec/mime-apps-spec-latest.html](https://specifications.freedesktop.org/mime-apps-spec/mime-apps-spec-latest.html) (currently v1.0.1), there is a new list of directories to look for mimeapps.list file.

This change is related to following request: https://github.com/lxde/libqtxdg/pull/141