### PR TITLE
Use absolute paths for DATAROOTDIR

### DIFF
--- a/lxqt-config-brightness/CMakeLists.txt
+++ b/lxqt-config-brightness/CMakeLists.txt
@@ -71,7 +71,7 @@ target_link_libraries(
 )
 
 add_definitions(
-    -DICON_DIR="${CMAKE_INSTALL_DATAROOTDIR}/icons/hicolor/48x48/apps"
+    -DICON_DIR="${CMAKE_INSTALL_FULL_DATAROOTDIR}/icons/hicolor/48x48/apps"
 )
 
 

--- a/lxqt-config-monitor/resources/configure.in
+++ b/lxqt-config-monitor/resources/configure.in
@@ -1,4 +1,4 @@
 #ifndef __CONFIG_H__
-#define ICON_PATH "${CMAKE_INSTALL_DATAROOTDIR}/lxqt/icons/"
+#define ICON_PATH "${CMAKE_INSTALL_FULL_DATAROOTDIR}/lxqt/icons/"
 #define __CONFIG_H__
 #endif


### PR DESCRIPTION
There are some warnings about missing files:
```
$ lxqt-config-brightness 
 (0x7ffcc2d2bcb0) Debug: No outputs have backlight property
 (0x7ffcc2d2bcb0) Debug: Found output: "VGA-1"
 (0x7ffcc2d2bcb0) Debug: Output: "VGA-1" added
 (0x7ffcc2d2bcb0) Debug: Found output: "HDMI-1"
 (0x7ffcc2d2bcb0) Debug: Output: "HDMI-1" added
 (0x7ffcc2d2bcb0) Debug: Found output: "HDMI-2"
 (0x7ffcc2d2bcb0) Debug: Output is not connected
 (0x7ffcc2d2bcb0) Warning: Cannot open file '/home/yen/Documents/share/icons/hicolor/48x48/apps/brightnesssettings.svg', because: No such file or directory                                                                                                                     
 (0x7ffcc2d2bcb0) Warning: Cannot open file '/home/yen/Documents/share/icons/hicolor/48x48/apps/brightnesssettings.svg', because: No such file or directory                                                                                                                     
 ((nil)) Warning: QFileSystemWatcher::removePaths: list is empty
 ((nil)) Warning: QFileSystemWatcher::removePaths: list is empty

$ lxqt-config-brightness
 (0x7ffc747d9870) Debug: No outputs have backlight property
 (0x7ffc747d9870) Debug: Found output: "VGA-1"
 (0x7ffc747d9870) Debug: Output: "VGA-1" added
 (0x7ffc747d9870) Debug: Found output: "HDMI-1"
 (0x7ffc747d9870) Debug: Output: "HDMI-1" added
 (0x7ffc747d9870) Debug: Found output: "HDMI-2"
 (0x7ffc747d9870) Debug: Output is not connected
 (0x7ffc747d9870) Warning: Cannot open file '/home/yen/Documents/share/icons/hicolor/48x48/apps/brightnesssettings.svg', because: No such file or directory                                                                                                                     
 (0x7ffc747d9870) Warning: Cannot open file '/home/yen/Documents/share/icons/hicolor/48x48/apps/brightnesssettings.svg', because: No such file or directory                                                                                                                     
 ((nil)) Warning: QFileSystemWatcher::removePaths: list is empty
 ((nil)) Warning: QFileSystemWatcher::removePaths: list is empty
```
And monitor images are missing in lxqt-config-monitor:
![image](https://user-images.githubusercontent.com/1937689/34433837-e7a600c0-ecbc-11e7-8246-e265fef6e058.png)
(I'm not sure where brightnesssettings.svg is used)

This is a regression after https://github.com/lxde/lxqt-config/pull/132. ```$CMAKE_INSTALL_DATAROOTDIR``` simply expands to ```share```, however in some cases absolute paths are necessary.