### PR TITLE
Prevent possible container detachments

### DIFF
--- a/lxqt-config-brightness/brightnesssettings.cpp
+++ b/lxqt-config-brightness/brightnesssettings.cpp
@@ -29,7 +29,7 @@ BrightnessSettings::BrightnessSettings(QWidget *parent):QDialog(parent)
     mBrightness = new XRandrBrightness();
     mMonitors = mBrightness->getMonitorsInfo();
 
-    for(const MonitorInfo &monitor: mMonitors)
+    for(const MonitorInfo &monitor: qAsConst(mMonitors))
     {
         OutputWidget *output = new OutputWidget(monitor, this);
         ui->layout->addWidget(output);
@@ -95,7 +95,7 @@ void BrightnessSettings::requestConfirmation()
     {
         // revert the changes
         mBrightness->setMonitorsSettings(mMonitors);
-        for (const auto & monitor : mMonitors)
+        for (const auto & monitor : qAsConst(mMonitors))
             emit monitorReverted(monitor);
     }
 }

--- a/lxqt-config-monitor/fastmenu.cpp
+++ b/lxqt-config-monitor/fastmenu.cpp
@@ -82,14 +82,16 @@ static bool sizeBiggerThan(const QSize &sizeA, const QSize &sizeB)
 
 void FastMenu::unified()
 {
-    KScreen::OutputList outputs = mConfig->outputs();
+    const KScreen::OutputList outputs = mConfig->outputs();
     // Look for common size
     QList<QSize> commonSizes;
     for (const KScreen::OutputPtr &output : outputs)
     {
         if( !output->isConnected() )
             continue;
-        for(const KScreen::ModePtr &mode: output->modes())
+
+        const auto modes = output->modes();
+        for(const KScreen::ModePtr &mode : modes)
         {
             commonSizes.append(mode->size());
         }
@@ -100,7 +102,8 @@ void FastMenu::unified()
         if( !output->isConnected() )
             continue;
         QList<QSize> sizes;
-        for(const KScreen::ModePtr &mode: output->modes())
+        const auto modes = output->modes();
+        for(const KScreen::ModePtr &mode : modes)
         {
             if( commonSizes.contains(mode->size()) )
                 sizes.append(mode->size());
@@ -124,7 +127,8 @@ void FastMenu::unified()
         output->setEnabled(true);
         // Select mode with the biggest refresh rate
         float maxRefreshRate = 0.0;
-        for(const KScreen::ModePtr &mode: output->modes())
+        const auto outputs = output->modes();
+        for(const KScreen::ModePtr &mode : outputs)
         {
             if(mode->size() == commonSize && maxRefreshRate < mode->refreshRate())
             {
@@ -138,7 +142,7 @@ void FastMenu::unified()
 void FastMenu::onlyFirst()
 {
     bool foundOk = false;
-    KScreen::OutputList outputs = mConfig->outputs();
+    const KScreen::OutputList outputs = mConfig->outputs();
     for (const KScreen::OutputPtr &output : outputs)
     {
         if( !output->isConnected() )
@@ -155,7 +159,7 @@ void FastMenu::onlyFirst()
 void FastMenu::onlySecond()
 {
     bool foundOk = true;
-    KScreen::OutputList outputs = mConfig->outputs();
+    const KScreen::OutputList outputs = mConfig->outputs();
     for (const KScreen::OutputPtr &output : outputs)
     {
         if( !output->isConnected() )

--- a/lxqt-config-monitor/monitorpicture.cpp
+++ b/lxqt-config-monitor/monitorpicture.cpp
@@ -128,7 +128,7 @@ void MonitorPictureDialog::updateMonitorWidgets(QString primaryMonitor)
     int x0, y0;
     x0 = y0 = 0;
 
-    for (MonitorPicture *picture : pictures)
+    for (MonitorPicture *picture : qAsConst(pictures))
     {
         if (picture->monitorWidget->output->name() == primaryMonitor
             || primaryMonitor == QStringLiteral(""))
@@ -141,7 +141,7 @@ void MonitorPictureDialog::updateMonitorWidgets(QString primaryMonitor)
 
     if( primaryMonitor == QStringLiteral("") )
     {
-        for(MonitorPicture *picture: pictures)
+        for(MonitorPicture *picture : qAsConst(pictures))
         {
             int x1 = picture->originX + picture->pos().x();
             int y1 = picture->originY + picture->pos().y();
@@ -150,7 +150,7 @@ void MonitorPictureDialog::updateMonitorWidgets(QString primaryMonitor)
         }
     }
 
-    for (MonitorPicture *picture : pictures)
+    for (MonitorPicture *picture : qAsConst(pictures))
     {
         int x = picture->originX + picture->pos().x() - x0;
         int y = picture->originY + picture->pos().y() - y0;
@@ -399,7 +399,7 @@ void MonitorPictureDialog::moveMonitorPictureToNearest(MonitorPicture* monitorPi
         return;
 
     QVector2D vector(0, 0);
-    for (MonitorPicture *picture : pictures)
+    for (MonitorPicture *picture : qAsConst(pictures))
     {
         if (picture == monitorPicture)
             continue;

--- a/lxqt-config-monitor/monitorwidget.cpp
+++ b/lxqt-config-monitor/monitorwidget.cpp
@@ -249,7 +249,8 @@ void MonitorWidget::updateRefreshRates()
     KScreen::ModePtr selectedMode = output->currentMode();
     if (selectedMode)
     {
-        for (const KScreen::ModePtr &mode : output->modes())
+        const auto modes = output->modes();
+        for (const KScreen::ModePtr &mode : modes)
             if (mode->size() == selectedMode->size())
                 ui.rateCombo->addItem(tr("%1 Hz").arg(mode->refreshRate()), mode->id());
 


### PR DESCRIPTION
Found them while performing the drop foreach task.
They hurt performance.